### PR TITLE
Makefile: Fix rule for stop target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ run:
 	docker compose exec app bash workflows/execute_workflows.sh > logs/run_$$(date +"%s").log
 
 stop:
-	CONTAINER_ID=$$(docker ps | grep quiver | cut -d' ' -f1); docker container stop $$CONTAINER_ID && docker container remove $$CONTAINER_ID
+	CONTAINER_ID=$$(docker ps | grep quiver | cut -d' ' -f1); docker container stop $$CONTAINER_ID && docker container rm $$CONTAINER_ID
 
 clean-workspaces:
 	docker compose exec app rm -rf workflows/workspaces

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: build clean clean-results clean-workspaces prepare-default-gt run start stop
+
 build:
 	docker compose build
 


### PR DESCRIPTION
Replace unsupported `docker container remove` by `docker container rm`.