### PR TITLE
Dockerfile: Replace apt by apt-get and run update before install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ WORKDIR /app
 
 COPY requirements.txt requirements.txt
 
-RUN apt install git
-RUN apt install -y jq
 RUN apt-get update
+RUN apt-get install git
+RUN apt-get install -y jq
 RUN apt-get install -y --fix-missing openjdk-11-jre
 
 COPY src src


### PR DESCRIPTION
`apt` is intended as an end user interface. It issues a warnings if it is used in a script. Therefore replace it by `apt-get`.

Run also `apt-get update` to update the package sources before running `apt-get install`.